### PR TITLE
TWI Driver Transmit Holding Register Ready Interrupt Race Condition

### DIFF
--- a/firmware_common/drivers/sam3u_i2c.c
+++ b/firmware_common/drivers/sam3u_i2c.c
@@ -545,13 +545,13 @@ void TWISM_Idle(void)
       /* Set up to transmit the message */
       TWI_u32CurrentBytesRemaining = TWI0->pTransmitBuffer->u32Size;
       TWI_pu8CurrentTxData = TWI0->pTransmitBuffer->pu8Message;
+      TWI0->u32Flags |= (_TWI_TRANSMITTING | _TWI_TRANS_NOT_COMP);
       TWI0FillTxBuffer();    
       
       /* Update the message's status */
       UpdateMessageStatus(TWI0->pTransmitBuffer->u32Token, SENDING);
   
       /* Proceed to next state to let the current message send */
-      TWI0->u32Flags |= (_TWI_TRANSMITTING | _TWI_TRANS_NOT_COMP);
       TWI_StateMachine = TWISM_Transmitting;
     }
     else if(TWI_MessageBuffer[TWI_MessageBufferCurIndex].Direction == READ)


### PR DESCRIPTION
The `TWI0FillTxBuffer()` function enables the Transmit Holding Register Ready Interrupt. This is done before the `_TWI_TRANSMITTING` flag is set. The interrupt can fire before the flag is set which results in an infinite firing of the interrupt as no action is taken by the IRQ handler to clear the Transmit Holding Register Ready Interrupt.

Moving the setting of the `_TWI_TRANSMITTING` flag prior to calling the `TWI0FillTxBuffer()` function ensures the interrupt is fired after the flag is set.

This race condition was observed using the GCC compiler which seems to have generated code that behaves differently than the IAR compiler and has exposed this race condition.